### PR TITLE
Added explicit encoding whern saving ERA5 netcds files

### DIFF
--- a/agromanagement/utility/data_downloaders.py
+++ b/agromanagement/utility/data_downloaders.py
@@ -173,7 +173,11 @@ def download_era(start_date, end_date, download_path=DEFAULT_DOWNLOAD_PATH):
         print(f"Combining monthly data for year '{year} ...'")
         datasets = [xr.open_dataset(file) for file in file_list]
         combined_dataset = xr.concat(datasets, dim="time")
-        combined_dataset.to_netcdf(f"{download_path}/ERA5_{year}.nc")
+        encoding = {
+            var: {"dtype": combined_dataset[var].dtype}
+            for var in combined_dataset.data_vars
+        }
+        combined_dataset.to_netcdf(f"{download_path}/ERA5_{year}.nc", encoding=encoding)
 
         for dataset in datasets:
             dataset.close()


### PR DESCRIPTION
Fixed issues with processing the weather data from ERA5 reanalysis.  
In detail, the following was changed here:
- [x] Addressed an encoding issue when saving yearly netcsdf files created concatenating monthly ones. This would result in some values being wrong (for example -10./-15 degrees celsius in July in the SW of England). It turns out it was an issue similar to [this](https://github.com/pydata/xarray/issues/6272) which I fixed specifically declaring the encoding when saving the data.

There is a good chance this was not a problem here (as I was only concatenating data rather than aggregating hourly into daily), but this makes sure that ecoding is appropriately handled. 