### PR TITLE
Downgraded Python version in Conda environment for SNAPP

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -10,7 +10,7 @@ jobs:
         node-version: [20.x]
         os: [macOS-latest, windows-latest, ubuntu-latest]
         python-version:
-          - 3.11.8
+          - 3.10.14
     defaults:
       run:
         shell: bash -el {0}

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3.11.8
+  - python=3.10.14
   - black
   - gdal
   - geopandas


### PR DESCRIPTION
The [ESA-SNAP app](https://step.esa.int/main/download/snap-download/) required to process Sentinel data for the algorithm to estimate Leaf Area Index only works with Python versions 3.6 to 3.10. Our Conda environment was set up to run with Python 3.11. With this PR we address issue #27 and downgrade the Python version to 3.10.14 with the following:  
- [x] Update agromanagment.yml file with the downgraded Python version;
- [x] Update CI workflow file with matching Python version